### PR TITLE
CI: grant write to packages in build-container

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   build-container:
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
I don't understand why this is needed, it wasn't in the previous organisation...