### PR TITLE
CI: grant read on packages in build-willow

### DIFF
--- a/.github/workflows/build-willow.yml
+++ b/.github/workflows/build-willow.yml
@@ -36,6 +36,8 @@ jobs:
       dist_filename: "willow-dist-${{ matrix.device }}.bin"
       ota_filename: "willow-ota-${{ matrix.device }}.bin"
       partitions_filename: "willow-partitions-${{ matrix.device }}"
+    permissions:
+      packages: read
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
For some fucked up reason CI keeps failing with useless error messages after the repo move to the new organization. The previous commit fixed part of it, and the next failure looks suspiciously like the previous failure, so let's try the next thing to fix it.

Seriously though, Github Actions is a total piece of fucking garbage.