### PR TITLE
CI: lowercase GHCR_URL

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       check_container_image: ${{ steps.check_container_image.outputs.result }}
       container_any_changed: ${{ steps.changed_files_yaml.outputs.container_any_changed }}
-      ghcr_url: ${{ env.GHCR_URL }}
+      ghcr_url: "${GHCR_URL@L}"
       image_any_changed: ${{ steps.changed_files_yaml.outputs.image_any_changed }}
       metadata_json: ${{ steps.metadata.outputs.json }}
       metadata_labels: ${{ steps.metadata.outputs.labels }}
@@ -54,7 +54,7 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.GHCR_URL }}
+          images: "${GHCR_URL@L}"
           tags: |
             type=ref,event=tag
             type=ref,event=pr


### PR DESCRIPTION
Attempt to fix the following error:

  invalid reference format: repository name (HeyWillow/willow) must be lowercase

This is just ridiculous. Seriously, Github Actions is useless.