### PR TITLE
lvgl: display buffer in SPIRAM

### DIFF
--- a/main/slvgl.c
+++ b/main/slvgl.c
@@ -102,13 +102,13 @@ esp_err_t init_lvgl_display(void)
     ESP_LOGD(TAG, "init_lvgl: lcdp->lcd_io_handle: %p", lcdp->lcd_io_handle);
 
     const lvgl_port_display_cfg_t cfg_ld = {
-        .buffer_size = LCD_H_RES * LCD_V_RES / 5,
-        .double_buffer = false,
+        .buffer_size = LCD_H_RES * LCD_V_RES,
+        .double_buffer = true,
         // DMA and SPIRAM
         // E (16:37:21.267) LVGL: lvgl_port_add_disp(190): Alloc DMA capable buffer in SPIRAM is not supported!
         .flags = {
-            .buff_dma = true,
-            .buff_spiram = false,
+            .buff_dma = false,
+            .buff_spiram = true,
         },
         .hres = LCD_H_RES,
         // confirmed this is correct by printf %p periph_lcd->lcd_io_handle in esp_peripherals/periph_lcd.c
@@ -120,6 +120,7 @@ esp_err_t init_lvgl_display(void)
             .mirror_y = LCD_MIRROR_Y,
             .swap_xy = LCD_SWAP_XY,
         },
+        .trans_size = LCD_H_RES * LCD_V_RES / 10,
         .vres = LCD_V_RES,
     };
 


### PR DESCRIPTION
It appears the problem of LVGL saturating an entire CPU core isn't fixed by the increased buffer size. When a response is long enough to trigger scrolling of the label on the display, Willow would crash sometimes even after the first occurence. The torture test command and response are not long enough to trigger scrolling, so it didn't catch this.

Further increasing the buffer then resulted in the TLS component not being able to allocate memory.

Let's try something completely different: display buffer in SPIRAM. This didn't work when I tried initially, and the screen would draw only partially. Then stumbled on trans_size in the esp_lvgl_port README. It appears enabling that, makes display buffer in SPIRAM work.

Since we have plenty SPIRAM, let's just create a buffer large enough for the entire screen, enable double buffering, and use a trans_size of 1/10 the screen size.

This is my last attempt to fix this horribly buggy scrolling feature before I disable it.