### PR TITLE
audio: turn on display in play_audio

### DIFF
--- a/main/audio.c
+++ b/main/audio.c
@@ -96,6 +96,9 @@ static void cb_ea(esp_audio_state_t *state, void *data)
 
 static void play_audio(const char *uri)
 {
+    reset_timer(hdl_display_timer, config_get_int("display_timeout", DEFAULT_DISPLAY_TIMEOUT), false);
+    display_set_backlight(true, false);
+
     audio_err_t err = esp_audio_play(hdl_ea, AUDIO_CODEC_TYPE_DECODER, uri, 0);
 
     if (err == ESP_ERR_AUDIO_OPEN) {


### PR DESCRIPTION
When an endpoint takes a long time to respond, the display timer might have already turned of the display when the response arrives. Reset the timer and turn on the display in play_audio so the display is always on when an audio response is played.