### PR TITLE
treewide: fix calloc args

### DIFF
--- a/main/audio.c
+++ b/main/audio.c
@@ -133,12 +133,12 @@ static void play_audio_wis_tts(void *data)
     wis_tts_url = config_get_char("wis_tts_url_v2", NULL);
     if (wis_tts_url != NULL) {
         int len_url = strlen(wis_tts_url) + strlen((char *)data) + 1;
-        url = calloc(sizeof(char), len_url);
+        url = calloc(len_url, sizeof(char));
         snprintf(url, len_url, "%s%s", wis_tts_url, (char *)data);
     } else {
         wis_tts_url = config_get_char("wis_tts_url", DEFAULT_WIS_TTS_URL);
         int len_url = strlen(wis_tts_url) + strlen(WIS_URL_TTS_ARG) + strlen((char *)data) + 1;
-        url = calloc(sizeof(char), len_url);
+        url = calloc(len_url, sizeof(char));
         snprintf(url, len_url, "%s%s%s", wis_tts_url, WIS_URL_TTS_ARG, (char *)data);
     }
 
@@ -454,7 +454,7 @@ static esp_err_t cb_ar_event(audio_rec_evt_t *are, void *data)
                 bool was_mode = config_get_bool("was_mode", DEFAULT_WAS_MODE);
                 char *command_endpoint = config_get_char("command_endpoint", DEFAULT_COMMAND_ENDPOINT);
                 char *json;
-                json = calloc(sizeof(char), 29 + strlen(lookup_cmd_multinet(command_id)));
+                json = calloc(29 + strlen(lookup_cmd_multinet(command_id)), sizeof(char));
                 snprintf(json, 29 + strlen(lookup_cmd_multinet(command_id)), "{\"text\":\"%s\",\"language\":\"en\"}",
                          lookup_cmd_multinet(command_id));
                 if (was_mode) {
@@ -592,7 +592,7 @@ static esp_err_t hdl_ev_hs_to_api(http_stream_event_msg_t *msg)
                 return ESP_FAIL;
             }
             // Allocate memory for response. Should be enough?
-            char *buf = calloc(sizeof(char), 2048);
+            char *buf = calloc(2048, sizeof(char));
             assert(buf);
             int read_len = esp_http_client_read(http, buf, 2048);
             if (read_len <= 0) {
@@ -917,7 +917,7 @@ static esp_err_t start_rec(void)
 static void at_read(void *data)
 {
     const int len = 2 * 1024;
-    char *buf = audio_calloc(1, len);
+    char *buf = audio_calloc(len, 1);
     int msg = -1, ret = 0;
     TickType_t delay = portMAX_DELAY;
 

--- a/main/config.c
+++ b/main/config.c
@@ -50,7 +50,7 @@ static char *config_read(void)
 
     ESP_LOGI(TAG, "config file size: %ld", fs.st_size);
 
-    config = calloc(sizeof(char), fs.st_size + 1);
+    config = calloc(fs.st_size + 1, sizeof(char));
     size_t rlen = fread(config, 1, fs.st_size, f);
     ESP_LOGI(TAG, "fread: %d", rlen);
     config[fs.st_size] = '\0';

--- a/main/endpoint/hass.c
+++ b/main/endpoint/hass.c
@@ -121,7 +121,7 @@ static void cb_ws_event(const void *arg_evh, const esp_event_base_t *base_ev, co
                 cJSON *speech2 = cJSON_GetObjectItemCaseSensitive(plain, "speech");
                 if (cJSON_IsString(speech2) && speech2->valuestring != NULL && strlen(speech2->valuestring) > 0) {
                     hir.has_speech = true;
-                    hir.speech = calloc(sizeof(char), strlen(speech2->valuestring) + 1);
+                    hir.speech = calloc(strlen(speech2->valuestring) + 1, sizeof(char));
                     snprintf(hir.speech, strlen(speech2->valuestring) + 1, "%s", speech2->valuestring);
                 }
 
@@ -205,7 +205,7 @@ static void hass_get_url(char **url, const char *path, const bool ws)
     if (path != NULL) {
         len_url += strlen(path);
     }
-    *url = calloc(sizeof(char), len_url);
+    *url = calloc(len_url, sizeof(char));
     snprintf(*url, len_url, "%s://%s:%d%s", scheme, hass_host, config_get_int("hass_port", DEFAULT_PORT),
              path ? path : "");
     free(hass_host);
@@ -244,7 +244,7 @@ static void init_hass_ws_client(void)
 
     hass_token = config_get_char("hass_token", DEFAULT_TOKEN);
     len_auth = strlen(hass_token) + 34;
-    auth = calloc(sizeof(char), len_auth);
+    auth = calloc(len_auth, sizeof(char));
     snprintf(auth, len_auth, "{\"type\":\"auth\",\"access_token\":\"%s\"}", hass_token);
     free(hass_token);
 
@@ -259,7 +259,7 @@ static void init_hass_ws_client(void)
 static esp_err_t hass_set_http_auth(const esp_http_client_handle_t hdl_hc)
 {
     char *hass_token = config_get_char("hass_token", DEFAULT_TOKEN);
-    char *hdr_auth = calloc(sizeof(char), 8 + strlen(hass_token));
+    char *hdr_auth = calloc(8 + strlen(hass_token), sizeof(char));
     snprintf(hdr_auth, 8 + strlen(hass_token), "Bearer %s", hass_token);
     free(hass_token);
     esp_err_t ret = esp_http_client_set_header(hdl_hc, "Authorization", hdr_auth);

--- a/main/http.c
+++ b/main/http.c
@@ -43,7 +43,7 @@ static esp_err_t http_do(const esp_http_client_handle_t hdl_hc, const esp_http_c
         ESP_LOGE(TAG, "failed to get HTTP headers");
         return ESP_FAIL;
     }
-    *body = calloc(sizeof(char), n + 1);
+    *body = calloc(n + 1, sizeof(char));
     n = esp_http_client_read_response(hdl_hc, *body, n);
     if (n >= 0) {
         *http_status = esp_http_client_get_status_code(hdl_hc);


### PR DESCRIPTION
The size arg to calloc should be the second arg. This fixes a bunch of warnings when building with ESP-IDF 5.4 / GCC 14.