### PR TITLE
Rework unmute and MIC gain handling

### DIFF
--- a/main/audio.c
+++ b/main/audio.c
@@ -4,7 +4,6 @@
 #include "audio_pipeline.h"
 #include "audio_thread.h"
 #include "board.h"
-#include "es7210.h"
 #include "esp_check.h"
 #include "esp_decoder.h"
 #include "esp_http_client.h"
@@ -1023,7 +1022,7 @@ void init_adc(void)
     };
 
     hdl_aha->audio_codec_config_iface(AUDIO_HAL_CODEC_MODE_ENCODE, &cfg_i2s);
-    es7210_adc_set_gain(ES7210_MIC_SELECT, config_get_int("mic_gain", DEFAULT_MIC_GAIN));
+    hdl_aha->audio_codec_set_volume(config_get_int("mic_gain", DEFAULT_MIC_GAIN));
 }
 
 esp_err_t init_audio(void)
@@ -1052,7 +1051,7 @@ esp_err_t init_audio(void)
     }
     free(speech_rec_mode);
     ESP_RETURN_ON_ERROR(start_rec(), TAG, "start_rec failed");
-    es7210_adc_set_gain(ES7210_MIC_SELECT, config_get_int("mic_gain", DEFAULT_MIC_GAIN));
+    hdl_aha->audio_codec_set_volume(config_get_int("mic_gain", DEFAULT_MIC_GAIN));
 
     ESP_LOGI(TAG, "app_main() - start_rec() finished");
 

--- a/main/audio.c
+++ b/main/audio.c
@@ -1008,6 +1008,11 @@ esp_err_t volume_set(int volume)
     return audio_hal_set_volume(hdl_ahc, volume);
 }
 
+static void init_adc(void)
+{
+    hdl_aha = audio_board_adc_init();
+}
+
 esp_err_t init_audio(void)
 {
     char *speech_rec_mode = config_get_char("speech_rec_mode", DEFAULT_SPEECH_REC_MODE);
@@ -1023,7 +1028,7 @@ esp_err_t init_audio(void)
     init_esp_audio();
     volume_set(-1);
 
-    hdl_aha = audio_board_adc_init();
+    init_adc();
 
     init_audio_response();
     init_session_timer();

--- a/main/audio.c
+++ b/main/audio.c
@@ -1008,7 +1008,7 @@ esp_err_t volume_set(int volume)
     return audio_hal_set_volume(hdl_ahc, volume);
 }
 
-static void init_adc(void)
+void init_adc(void)
 {
     if (hdl_aha != NULL) {
         hdl_aha->audio_codec_deinitialize();
@@ -1023,6 +1023,7 @@ static void init_adc(void)
     };
 
     hdl_aha->audio_codec_config_iface(AUDIO_HAL_CODEC_MODE_ENCODE, &cfg_i2s);
+    es7210_adc_set_gain(ES7210_MIC_SELECT, config_get_int("mic_gain", DEFAULT_MIC_GAIN));
 }
 
 esp_err_t init_audio(void)
@@ -1043,7 +1044,6 @@ esp_err_t init_audio(void)
     if (hdl_aha == NULL) {
         init_adc();
     }
-
 
     init_audio_response();
     init_session_timer();

--- a/main/audio.c
+++ b/main/audio.c
@@ -1011,6 +1011,15 @@ esp_err_t volume_set(int volume)
 static void init_adc(void)
 {
     hdl_aha = audio_board_adc_init();
+
+    audio_hal_codec_i2s_iface_t cfg_i2s = {
+        .mode = AUDIO_HAL_MODE_SLAVE,
+        .fmt = AUDIO_HAL_I2S_NORMAL,
+        .samples = AUDIO_HAL_16K_SAMPLES,
+        .bits = AUDIO_HAL_BIT_LENGTH_32BITS,
+    };
+
+    hdl_aha->audio_codec_config_iface(AUDIO_HAL_CODEC_MODE_ENCODE, &cfg_i2s);
 }
 
 esp_err_t init_audio(void)

--- a/main/audio.c
+++ b/main/audio.c
@@ -1010,6 +1010,9 @@ esp_err_t volume_set(int volume)
 
 static void init_adc(void)
 {
+    if (hdl_aha != NULL) {
+        hdl_aha->audio_codec_deinitialize();
+    }
     hdl_aha = audio_board_adc_init();
 
     audio_hal_codec_i2s_iface_t cfg_i2s = {
@@ -1037,7 +1040,10 @@ esp_err_t init_audio(void)
     init_esp_audio();
     volume_set(-1);
 
-    init_adc();
+    if (hdl_aha == NULL) {
+        init_adc();
+    }
+
 
     init_audio_response();
     init_session_timer();

--- a/main/audio.h
+++ b/main/audio.h
@@ -22,6 +22,7 @@ extern QueueHandle_t q_rec;
 extern struct willow_audio_response war;
 
 void deinit_audio(void);
+void init_adc(void);
 esp_err_t init_audio(void);
 void play_audio_ok(void *data);
 esp_err_t volume_set(int volume);

--- a/main/input.c
+++ b/main/input.c
@@ -1,10 +1,10 @@
-#include "es7210.h"
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_peripherals.h"
 #include "input_key_service.h"
 #include "periph_button.h"
 
+#include "audio.h"
 #include "config.h"
 #include "shared.h"
 #include "system.h"
@@ -20,20 +20,7 @@ static esp_err_t cb_iks(periph_service_handle_t hdl, periph_service_event_t *ev,
     if (key == INPUT_KEY_USER_ID_MUTE) {
         if (ev->type == INPUT_KEY_SERVICE_ACTION_PRESS_RELEASE) {
             ESP_LOGI(TAG, "unmute");
-            audio_hal_codec_config_t cfg_ahc = {
-                .adc_input  = AUDIO_HAL_ADC_INPUT_LINE1,
-                .dac_output = AUDIO_HAL_DAC_OUTPUT_ALL,
-                .codec_mode = AUDIO_HAL_CODEC_MODE_BOTH,
-                .i2s_iface = {
-                    .mode = AUDIO_HAL_MODE_SLAVE,
-                    .fmt = AUDIO_HAL_I2S_NORMAL,
-                    .samples = AUDIO_HAL_16K_SAMPLES,
-                    .bits = AUDIO_HAL_BIT_LENGTH_32BITS,
-                },
-            };
-
-            es7210_adc_init(&cfg_ahc);
-            es7210_adc_set_gain(ES7210_MIC_SELECT, config_get_int("mic_gain", DEFAULT_MIC_GAIN));
+            init_adc();
         }
     }
 

--- a/main/shared.h
+++ b/main/shared.h
@@ -2,7 +2,3 @@
 #define DEFAULT_MIC_GAIN         14
 #define DEFAULT_SPEECH_REC_MODE  "WIS"
 #define DEFAULT_WAS_MODE         false
-
-#ifndef ES7210_MIC_SELECT
-#define ES7210_MIC_SELECT (ES7210_INPUT_MIC1 | ES7210_INPUT_MIC2)
-#endif


### PR DESCRIPTION
Apparently the ESP32-S3-BOX-Lite uses different audio chips than the other ESP32-S3-BOX variants. We unconditionally call es7210_adc_set_gain() to set the MIC gain, and with ESP-ADF 2.7 and ESP-IDF 5.3, using the new I2C driver, this causes a crash due to the es7210 i2c_handle being NULL.

Fix this by using audio_codec_set_volume on the ADC audio handle. Also replace es7210_adc_set_gain in the input key service callback, to have consistent code.

Fixes: #437